### PR TITLE
fix and simplify callsCsvToJson

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -39,7 +39,7 @@ fritzFormat.calls = (calls) => {
 fritzFormat.callsCsvToJson = (csvData) => {
   // Replace the CSV column titles with the English format and remove unnecessary lines
   let lines = csvData.split('\n')
-  lines.splice(0,1) // removes 'sep=;'
+  lines.splice(0, 1) // removes 'sep=;'
   lines[0] = 'Type;Date;Name;Number;Extension;NumberSelf;Duration'
   let parsableCsvData = lines.join('\n').trim()
 

--- a/src/format.js
+++ b/src/format.js
@@ -37,18 +37,11 @@ fritzFormat.calls = (calls) => {
  * @return {Object}
  */
 fritzFormat.callsCsvToJson = (csvData) => {
-  // Replace the CSV column titles with the English format.
+  // Replace the CSV column titles with the English format and remove unnecessary lines
   let lines = csvData.split('\n')
-  lines[1] = 'Type;Date;Name;Telephone number;Extension;Telephone Number;Duration'
-  csvData = lines.join('\n')
-
-  // We remove the separator definition and shorten some column titles, so that
-  // the csv to json module can parse them correctly.
-  let parsableCsvData = csvData
-                        .replace('sep=;', '')
-                        .replace('Extension;Telephone number', 'Extension;NumberSelf')
-                        .replace('Telephone number', 'Number')
-                        .trim()
+  lines.splice(0,1) // removes 'sep=;'
+  lines[0] = 'Type;Date;Name;Number;Extension;NumberSelf;Duration'
+  let parsableCsvData = lines.join('\n').trim()
 
   // Format the CSV to a json object and return the result.
   const formattedBody = csvjson.toObject(parsableCsvData, {delimiter: ';'})


### PR DESCRIPTION
there is an issue with replacing the column titles after adding them to the CSV data.
Has been simplified to directly set the expected column titles instead of setting them and afterwards changing them