### PR TITLE
feat: load counter info

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -53,7 +53,7 @@ fritzSystem.getCounter = async (options) => {
   }
 
   // Check the version first, because the structure is parsable from v7.25 and up
-  const version = await fritzSystem.getVersionNumber();
+  const version = await fritzSystem.getVersionNumber(options);
   if (version.error) {
     return version;
   }

--- a/test/onlinecounter.js
+++ b/test/onlinecounter.js
@@ -1,0 +1,19 @@
+const fritz = require('../index.js')
+const options = require('../package.json').options
+const fs = require('fs')
+
+async function getCounterInfo () {
+  const sessionId = await fritz.getSessionId(options)
+  options.sid = sessionId
+
+  const counterInfo = await fritz.getCounter(options)
+
+  if (counterInfo.error) {
+    console.log('Error:', counterInfo.error.message)
+    process.exit(1)
+  }
+
+  fs.writeFileSync('counterInfo.json', JSON.stringify(counterInfo, null, 2))
+}
+
+getCounterInfo()


### PR DESCRIPTION
After creating a sessionId, the new function is able to load the online counter info, which includes the amount of bytes, that has been transferred through the network in specific time ranges